### PR TITLE
Use latch in test

### DIFF
--- a/instrumentation/httpurlconnection/testing/src/main/kotlin/io/opentelemetry/instrumentation/library/httpurlconnection/HttpUrlConnectionTestUtil.kt
+++ b/instrumentation/httpurlconnection/testing/src/main/kotlin/io/opentelemetry/instrumentation/library/httpurlconnection/HttpUrlConnectionTestUtil.kt
@@ -18,6 +18,7 @@ object HttpUrlConnectionTestUtil {
         inputUrl: String,
         getInputStream: Boolean = true,
         disconnect: Boolean = true,
+        onComplete: Runnable = Runnable {},
     ) {
         var connection: HttpURLConnection? = null
         try {
@@ -33,6 +34,7 @@ object HttpUrlConnectionTestUtil {
             Log.e(TAG, "Exception occurred while executing GET request", e)
         } finally {
             connection?.takeIf { disconnect }?.disconnect()
+            onComplete.run()
         }
     }
 


### PR DESCRIPTION
One example of making a test less flaky by leveraging a long timeout before failure and a latch for speeding up the happy path.